### PR TITLE
Set container restart policy

### DIFF
--- a/tasks/start_server.yml
+++ b/tasks/start_server.yml
@@ -28,6 +28,8 @@
   docker_container:
     name: "{{ repo_server_name }}"
     image: nginx
+    restart_policy: 'unless-stopped'
+    restart_retries: 3
     volumes:
       - "{{ repo_server_docroot }}:/data/www:ro"
       - "{{ repo_server_conf }}:/etc/nginx/nginx.conf:ro"


### PR DESCRIPTION
This changes the default behaviour so that the repo server container
restarts if the docker daemon is restarted, for example during a reboot.
The previous behaviour was that the repo server wouldn't restart.