### PR TITLE
Fixes issue starting nginx

### DIFF
--- a/tasks/start_server.yml
+++ b/tasks/start_server.yml
@@ -28,7 +28,7 @@
   docker_container:
     name: "{{ repo_server_name }}"
     image: nginx
-    restart_policy: 'unless-stopped'
+    restart_policy: 'on-failure'
     restart_retries: 3
     volumes:
       - "{{ repo_server_docroot }}:/data/www:ro"


### PR DESCRIPTION
Fixes an issue where nginx would not start because
both maximum-retry-count and restart policy 'unless-stopped' were
used together.

Originates from change to Docker API to validate restart policies.

Fixes #4